### PR TITLE
fix(playground): fix compilation errors and added missing types in ng-metadata.legacy.d.ts

### DIFF
--- a/playground/app/components/tabs/contentChild.ts
+++ b/playground/app/components/tabs/contentChild.ts
@@ -14,4 +14,7 @@ export class TabsContentComponent implements OnChildrenChanged,AfterViewInit, On
     @Inject(forwardRef(()=>TabsComponent)) @Host() private tabs: TabsComponent
   ){}
 
+  ngAfterViewInit(){}
+  
+  ngOnDestroy(){}
 }

--- a/playground/app/components/tabs/tabs.ts
+++ b/playground/app/components/tabs/tabs.ts
@@ -6,7 +6,9 @@ import {
   ViewChildren,
   ContentChild,
   ContentChildren,
+  AfterViewInit,
   AfterViewChecked,
+  AfterContentInit,
   AfterContentChecked,
   OnChildrenChanged
 } from 'ng-metadata/core';

--- a/playground/app/components/tabs/viewChild.ts
+++ b/playground/app/components/tabs/viewChild.ts
@@ -15,5 +15,8 @@ export class TabsChildComponent implements AfterViewInit, OnDestroy{
     @Inject(forwardRef(()=>TabsComponent)) @Host() private tabs: TabsComponent
   ){}
 
+  ngAfterViewInit(){}
+  
+  ngOnDestroy(){}
 
 }

--- a/playground/app/directives/my-validator.directive.ts
+++ b/playground/app/directives/my-validator.directive.ts
@@ -18,9 +18,14 @@ export class MyValidatorDirective implements OnInit,AfterContentInit{
   }
   ngAfterContentInit(){
     console.log( this.todoSvc );
-    this.ngModelCtrl.$validators["myValidator"] = (viewValue,modelValue)=>{
+    (this.ngModelCtrl.$validators as ImyValidators).myValidator = (viewValue,modelValue)=>{
       return viewValue ==='Martin';
     }
   }
 
+}
+
+//interface to have strict typecheck for custom myValidator and avoid this.ngModelCtrl.$validators["myValidator"]
+interface ImyValidators extends ng.IModelValidators {
+    myValidator: (modelValue: any, viewValue: any) => boolean
 }

--- a/playground/app/directives/my-validator.directive.ts
+++ b/playground/app/directives/my-validator.directive.ts
@@ -18,7 +18,7 @@ export class MyValidatorDirective implements OnInit,AfterContentInit{
   }
   ngAfterContentInit(){
     console.log( this.todoSvc );
-    this.ngModelCtrl.$validators.myValidator = (viewValue,modelValue)=>{
+    this.ngModelCtrl.$validators["myValidator"] = (viewValue,modelValue)=>{
       return viewValue ==='Martin';
     }
   }

--- a/playground/app/directives/my-validator.directive.ts
+++ b/playground/app/directives/my-validator.directive.ts
@@ -18,7 +18,8 @@ export class MyValidatorDirective implements OnInit,AfterContentInit{
   }
   ngAfterContentInit(){
     console.log( this.todoSvc );
-    (this.ngModelCtrl.$validators as ImyValidators).myValidator = (viewValue,modelValue)=>{
+    (this.ngModelCtrl.$validators as ImyValidators).myValidator = (modelValue,viewValue)=>{
+      var value = modelValue || viewValue;
       return viewValue ==='Martin';
     }
   }

--- a/playground/ng-metadata.legacy.d.ts
+++ b/playground/ng-metadata.legacy.d.ts
@@ -55,6 +55,9 @@ declare module ngMetadataCore{
   export function Optional(): ParameterDecorator;
   export function Host(): ParameterDecorator;
   export function Parent(): ParameterDecorator;
+  export function Self(): ParameterDecorator;
+  export function SkipSelf(): ParameterDecorator;
+  export function HostListener(eventName:string): MethodDecorator;
 
   /**
    * Factory for {@link ContentChildren}.
@@ -492,8 +495,76 @@ declare module ngMetadataCore{
   export interface OnChildrenChanged {
     _ngOnChildrenChanged?(): any;
   }
+ 
+  export interface OnChanges { 
+    ngOnChanges(changes: {[key: string]: {
+      previousValue: any,
+      currentValue: any,
+      isFirstChange(): boolean
+    }}); 
+  }
+}
 
-
+declare module ngMetadataCommon {
+  export const CORE_DIRECTIVES: Type[]
+  export abstract class NgModel implements ng.INgModelController {
+    $viewValue: any;
+    $modelValue: any;
+    $parsers: ng.IModelParser[];
+    $formatters: ng.IModelFormatter[];
+    $viewChangeListeners: ng.IModelViewChangeListener[];
+    $error: any;
+    $name: string;
+    $touched: boolean;
+    $untouched: boolean;
+    $validators: ng.IModelValidators;
+    $asyncValidators: ng.IAsyncModelValidators;
+    $pending: any;
+    $pristine: boolean;
+    $dirty: boolean;
+    $valid: boolean;
+    $invalid: boolean;
+    $render(): void;
+    $setValidity(validationErrorKey: string, isValid: boolean): void;
+    $setViewValue(value: any, trigger?: string): void;
+    $setPristine(): void;
+    $setDirty(): void;
+    $validate(): void;
+    $setTouched(): void;
+    $setUntouched(): void;
+    $rollbackViewValue(): void;
+    $commitViewValue(): void;
+    $isEmpty(value: any): boolean;
+  }
+  export abstract class NgForm implements ng.IFormController {
+    $pristine: boolean;
+    $dirty: boolean;
+    $valid: boolean;
+    $invalid: boolean;
+    $submitted: boolean;
+    $error: any;
+    $addControl(control: angular.INgModelController): void;
+    $removeControl(control: angular.INgModelController): void;
+    $setValidity(validationErrorKey: string, isValid: boolean, control: angular.INgModelController): void;
+    $setDirty(): void;
+    $setPristine(): void;
+    $commitViewValue(): void;
+    $rollbackViewValue(): void;
+    $setSubmitted(): void;
+    $setUntouched(): void;
+  }
+  export abstract class NgSelect {
+    ngModelCtrl: ng.INgModelController;
+    unknownOption: ng.IAugmentedJQuery;
+    renderUnknownOption(val: string): void;
+    removeUnknownOption(): void;
+    abstract readValue(): string;
+    writeValue(value: string): void;
+    addOption(value: string, element: ng.IAugmentedJQuery): void;
+    removeOption(value: any): void;
+    abstract hasOption(value: any): boolean;
+    registerOption(optionScope: ng.IScope, optionElement: ng.IAugmentedJQuery, optionAttrs: ng.IAttributes, interpolateValueFn?: Function, interpolateTextFn?: Function): void;
+  }
 }
 declare module "ng-metadata/core" {
   export = ngMetadataCore;
@@ -502,6 +573,9 @@ declare module "ng-metadata/platform" {
   export = ngMetadataPlatform;
 }
 
+declare module "ng-metadata/common" {
+  export = ngMetadataCommon
+}
 declare type Type = Function;
 declare type ProvideSpreadType = string|Type;
 


### PR DESCRIPTION
Hi I was trying ngMetadata after your last 1.5.0 release, and I found some compilation error using the playground, some was simple implementations method missing in components/tabs

But for fixing the missing decorators: `@Self` and `@SkipSelf` plus the missing declaration: `OnChanges`, `NgForm` and `NgModel` introduces in last release, I had to make some additions in ng-metadata.legacy.d.ts 

I don't know if those are aligned to your coding style, but it allows to me to successfully build the TS code with    npm run playground
Hope this can help and be accepted 