### PR TITLE
feat(platform/bootstrap): use bootstrap with module name instead of n…

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -90,7 +90,8 @@ import { bootstrap } from 'ng-metadata/platform';
 class App { }
 
 const AppModule = angular.module('app', [])
-  .directive( ...provide(App) );
+  .directive( ...provide(App) )
+  .name;
 
 bootstrap(AppModule);
 ```
@@ -99,7 +100,7 @@ bootstrap(AppModule);
 
 | Parameter     | Type                            | Description                               |
 | ------------- | ------------------------------- |------------------------------------------ |
-| **ngModule**  | `ngModule`                      | angular module                            |
+| **ngModule**  | `string`                        | angular module name                       |
 | **element?**  | `Element` or `string`(selector) | you can provide on which element or selector you want to boot your app. Default element is `document` |
 
 returns `undefined`
@@ -1746,8 +1747,9 @@ export class App {
 }
 
 const AppModule = angular.module('myApp',[])
-.directive(...provide(MyComponent))
-.directive(...provide(App));
+  .directive(...provide(MyComponent))
+  .directive(...provide(App))
+  .name;
 
 bootstrap(AppModule);
 ```

--- a/playground/app/app.ts
+++ b/playground/app/app.ts
@@ -85,5 +85,4 @@ export const AppModule = angular.module( 'app', [TabsModule] )
       // }
     }
   })*/
-
-  ;
+  .name;

--- a/playground/ng-metadata.legacy.d.ts
+++ b/playground/ng-metadata.legacy.d.ts
@@ -1,7 +1,7 @@
 declare module ngMetadataPlatform{
 
   type AppRoot = string | Element | Document;
-  function bootstrap(ngModule: ng.IModule, {element, strictDi}?: {
+  function bootstrap(ngModule: string, {element, strictDi}?: {
     element?: AppRoot;
     strictDi?: boolean;
   }): void;

--- a/src/platform/browser.ts
+++ b/src/platform/browser.ts
@@ -2,12 +2,12 @@ export type AppRoot = string | Element | Document;
 
 /**
  * bootstrap angular app
- * @param {ng.IModule}  ngModule
+ * @param {string}  ngModuleName
  * @param {string | Element | Document} [element=document]
  * @param {boolean} [strictDi=true]
  */
 export function bootstrap(
-  ngModule: ng.IModule,
+  ngModuleName: string,
   {element=document,strictDi=true}: {
     element?: AppRoot,
     strictDi?: boolean
@@ -17,7 +17,7 @@ export function bootstrap(
   const appRoot = _getAppRoot( element );
 
   angular.element( document ).ready( ()=> {
-    angular.bootstrap( appRoot, [ ngModule.name ], {
+    angular.bootstrap( appRoot, [ ngModuleName ], {
       strictDi: true
     } )
   } );


### PR DESCRIPTION
…gModule object

BREAKING CHANGE:

- you need to export .name from your registered module.
- This brings consistency across the whole app, because it's by default that Angular 1 exports module names for consumer and this is also aligned with ngUpgrade

before:
```typescript
import { provide, Component } from 'ng-metadata/core';
import { bootstrap } from 'ng-metadata/platform';

@Component({ selector: 'app', template: 'Hello World!' })
class App { }

const AppModule = angular.module('app', [])
  .directive( ...provide(App) );

bootstrap(AppModule);
```

after:
```typescript
import { provide, Component } from 'ng-metadata/core';
import { bootstrap } from 'ng-metadata/platform';

@Component({ selector: 'app', template: 'Hello World!' })
class App { }

const AppModule = angular.module('app', [])
  .directive( ...provide(App) )
  .name;

bootstrap(AppModule);
```