### PR TITLE
docs(README): sample module bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ import {HeroService} from './hero.service';
 
 export const HeroModule = angular.module('hero',[])
   .directive(...provide(HeroComponent))
-  .service(...provide(HeroService));
+  .service(...provide(HeroService))
+  .name;
   
 // hero.service.ts
 import {Injectable, Inject} from 'ng-metadata/core';   


### PR DESCRIPTION
Fixed sample in README.md to export module name for bootstrap app, according to changes in ngMetadata v1.5.2