### PR TITLE
docs(bootstrap): Fix manual module creation example to use .name

### DIFF
--- a/docs/recipes/bootstrap.md
+++ b/docs/recipes/bootstrap.md
@@ -104,7 +104,7 @@ import { AdminDirectives, AdminProviders, AdminPipes, adminConfig } from './modu
 })
 export class AdminComponent{}
 
-const AdminModule = bundle(AdminComponent,[adminConfig]);
+const AdminModule = bundle(AdminComponent,[adminConfig]).name;
 
 export const AppModule = angular.module('myApp',[UserModule, AdminModule]);
 ```


### PR DESCRIPTION
https://github.com/ngParty/ng-metadata/issues/124