### PR TITLE
fix(testing): Add a check on attributes before assigning to element i…

### DIFF
--- a/src/testing/utils.ts
+++ b/src/testing/utils.ts
@@ -45,8 +45,9 @@ export function renderFactory( $compile: ng.ICompileService, $scope: any ) {
 
     }
 
-    jqHost.attr(attrs);
-
+    if (attrs){
+      jqHost.attr(attrs);
+    }
     if (jqChildren) {
       jqHost.append(jqChildren);
     }

--- a/src/testing/utils.ts
+++ b/src/testing/utils.ts
@@ -44,7 +44,7 @@ export function renderFactory( $compile: ng.ICompileService, $scope: any ) {
       jqHost = angular.element( hostElement );
 
     }
-
+    // since attributes can be undefined we check them
     if (attrs){
       jqHost.attr(attrs);
     }


### PR DESCRIPTION
renderFactory

In testing/utils we assign attr() to the jqHost without checking if attrs is valid. This causes an error when
attrs is undefined making the renderFactory approach to testing unusable.

none