### PR TITLE
fix(directive_utils._setupDestroyHandler): removed element.off() on s…

### DIFF
--- a/src/core/directives/directives_utils.ts
+++ b/src/core/directives/directives_utils.ts
@@ -40,6 +40,5 @@ export function _setupDestroyHandler(
 
     watchersToDispose.forEach( _watcherDispose=>_watcherDispose() );
     observersToDispose.forEach( _observerDispose=>_observerDispose() );
-    element.off();
   } );
 }

--- a/test/core/directives/directives_utils.spec.ts
+++ b/test/core/directives/directives_utils.spec.ts
@@ -75,14 +75,28 @@ describe( `directives/directives_utils`, () => {
     it( `should properly setup cleanup on directive destroy`, () => {
 
       sandbox.spy( ctrl, 'ngOnDestroy' );
-      sandbox.spy( $element, 'off' );
 
       _setupDestroyHandler( $scope as any, $element as any, ctrl, true, watchers, observers );
 
       $scope.$$events[ 0 ].cb();
 
       expect( (ctrl.ngOnDestroy as Sinon.SinonSpy).called ).to.equal( true );
-      expect( ($element.off as Sinon.SinonSpy).called ).to.equal( true );
+
+    } );
+
+    it( `should trigger $element.$destroy event on element removal`, () => {
+
+      var destroyHandlerSpy = sandbox.spy();
+
+      $element.on( "$destroy", destroyHandlerSpy );
+
+      _setupDestroyHandler( $scope as any, $element as any, ctrl, true, watchers, observers );
+
+      $scope.$$events[ 0 ].cb();
+
+      $element.remove();
+
+      expect( destroyHandlerSpy.called ).to.equal( true );
 
     } );
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -325,7 +325,7 @@ export function ElementFactory() {
       this._eventListeners.push({ eventName, cb } )
     },
     off(eventName?){
-
+      if(!eventName) this._eventListeners = [];
     },
     eq(idx:number){
       return isArray(_$element) ? _$element[idx] : _$element
@@ -338,7 +338,12 @@ export function ElementFactory() {
     injector(){
       return $InjectorStatic
     },
-    controller( ctrlName: string ){}
+    controller( ctrlName: string ){},
+    remove(){
+      this._eventListeners.forEach(function(evtHandler:{eventName:string, cb:Function}) {
+        if(evtHandler.eventName === "$destroy") evtHandler.cb();
+      });
+    }
   };
 
   return _$element;


### PR DESCRIPTION
…cope  event

element.off() is not necessary as it is executed by jqLite on element removal.

fixes #143