### PR TITLE
RC 6 module should be passed to UpgradeAdapter

### DIFF
--- a/src/upgrade/upgrade_adapter.ts
+++ b/src/upgrade/upgrade_adapter.ts
@@ -15,7 +15,7 @@ export class NgMetadataUpgradeAdapter {
     /**
      * Manage the @angular/upgrade singleton
      */
-    this._upgradeAdapter = new UpgradeAdapter();
+    this._upgradeAdapter = UpgradeAdapter;
     /**
      * Used to bootstrap a hybrid Angular 1 and Angular 2 application,
      * using the same signature as `bootstrap` from ng-metadata/platform-browser-dynamic

--- a/src/upgrade/upgrade_adapter.ts
+++ b/src/upgrade/upgrade_adapter.ts
@@ -15,7 +15,7 @@ export class NgMetadataUpgradeAdapter {
     /**
      * Manage the @angular/upgrade singleton
      */
-    this._upgradeAdapter = UpgradeAdapter;
+    this._upgradeAdapter = (typeof UpgradeAdapter === "function") ? new UpgradeAdapter() : UpgradeAdapter ;
     /**
      * Used to bootstrap a hybrid Angular 1 and Angular 2 application,
      * using the same signature as `bootstrap` from ng-metadata/platform-browser-dynamic


### PR DESCRIPTION
RC 6 now requires a module to be passed to UpgradeAdapter
To use the the adaptater with the rc5+  we should be free to instantiate the upgradeAdapter by ourself.
Cheers