### PR TITLE
refactor(core): Add NgModule, use it for angular1Module bundling

### DIFF
--- a/core.ts
+++ b/core.ts
@@ -3,6 +3,7 @@ export { bundle } from './src/core/util'
 export {
   Directive,
   Component,
+  NgModule,
   Attr,
   Input,
   Output,

--- a/src/core/di/provider_util.ts
+++ b/src/core/di/provider_util.ts
@@ -1,5 +1,5 @@
 import { isString, isPresent } from '../../facade/lang';
-import { DirectiveMetadata, ComponentMetadata } from '../directives/metadata_directives';
+import { DirectiveMetadata, ComponentMetadata, NgModuleMetadata } from '../directives/metadata_directives';
 import { PipeMetadata } from '../pipes/metadata';
 
 import { Provider } from './provider';
@@ -49,4 +49,8 @@ export function isPipe(annotation: any): annotation is PipeMetadata {
 }
 export function isInjectMetadata( injectMeta: any ): injectMeta is InjectMetadata {
   return injectMeta instanceof InjectMetadata;
+}
+
+export function isNgModule( annotation: any ): annotation is NgModuleMetadata {
+  return isPresent( annotation.declarations ) && annotation instanceof NgModuleMetadata
 }

--- a/src/core/di/reflective_provider.ts
+++ b/src/core/di/reflective_provider.ts
@@ -50,7 +50,7 @@ export function resolveReflectiveProvider( provider: Provider ): {method: string
  * @returns {any}
  * @private
  */
-export function _getNgModuleMetadataByType( injectable: Type ): { providerName: string, providerMethod: string, moduleMethod: string} {
+export function _getAngular1ModuleMetadataByType( injectable: Type ): { providerName: string, providerMethod: string, moduleMethod: string} {
   // only the first class annotations is injectable
   const [annotation] = reflector.annotations( injectable );
 
@@ -135,7 +135,7 @@ export function _normalizeProviders(
       // const provider = createProvider( {provide:b, useClass:b} );
       // const { method, name, value } = resolveReflectiveProvider( provider );
       const [name,value] = provide( providerType );
-      const { providerName, providerMethod, moduleMethod } = _getNgModuleMetadataByType( providerType );
+      const { providerName, providerMethod, moduleMethod } = _getAngular1ModuleMetadataByType( providerType );
 
       // config phase support
       if ( isType( name ) ) {

--- a/src/core/directives/decorators.ts
+++ b/src/core/directives/decorators.ts
@@ -9,7 +9,9 @@ import {
   OutputMetadata,
   HostBindingMetadata,
   HostListenerMetadata,
-  LegacyDirectiveDefinition
+  LegacyDirectiveDefinition,
+  NgModuleMetadataType,
+  NgModuleMetadata
 } from './metadata_directives';
 import { ChangeDetectionStrategy } from '../change_detection/constants';
 
@@ -27,6 +29,15 @@ export interface DirectiveDecorator extends TypeDecorator {}
  * See {@link ComponentMetadataFactory}.
  */
 export interface ComponentDecorator extends DirectiveDecorator {}
+
+/**
+ * Interface for the {@link NgModuleMetadata} decorator function.
+ *
+ * See {@link NgModuleMetadataFactory}.
+ *
+ * @stable
+ */
+export interface NgModuleDecorator extends TypeDecorator {}
 
 /**
  * {@link DirectiveMetadata} factory for creating annotations, decorators.
@@ -194,6 +205,16 @@ export interface HostListenerMetadataFactory {
   new (eventName: string, args?: string[]): any;
 }
 
+/**
+ * {@link NgModuleMetadata} factory for creating annotations, decorators or DSL.
+ *
+ * @experimental
+ */
+export interface NgModuleMetadataFactory {
+  (obj?: NgModuleMetadataType): NgModuleDecorator;
+  new (obj?: NgModuleMetadataType): NgModuleMetadata;
+}
+
 
 export const Component: ComponentMetadataFactory = makeDecorator(ComponentMetadata) as ComponentMetadataFactory;
 
@@ -221,3 +242,10 @@ export const Output: OutputMetadataFactory = makePropDecorator(OutputMetadata);
 export const HostBinding: HostBindingMetadataFactory = makePropDecorator(HostBindingMetadata);
 
 export const HostListener: HostListenerMetadataFactory = makePropDecorator(HostListenerMetadata);
+
+/**
+ * Declares an ng module.
+ * @experimental
+ * @Annotation
+ */
+export const NgModule: NgModuleMetadataFactory = makeDecorator(NgModuleMetadata) as NgModuleMetadataFactory;

--- a/src/core/directives/metadata_directives.ts
+++ b/src/core/directives/metadata_directives.ts
@@ -1225,3 +1225,38 @@ export class HostBindingMetadata {
 export class HostListenerMetadata {
   constructor(public eventName: string, public args?: string[]) {}
 }
+
+/**
+ * Interface for creating NgModuleMetadata
+ */
+export interface NgModuleMetadataType {
+  providers?: any[]; // Decorated providers
+  declarations?: Array<Type|Type[]>; // Decorated Components, Directives or Pipes
+  imports?: Array<Type|string>; // Other NgModules or string names of Angular 1 modules
+  exports?: Array<Type|any[]>; // Not used, only here for interface compatibility
+  entryComponents?: Array<Type|any[]>; // Not used, only here for interface compatibility
+  bootstrap?: Array<Type|any[]>; // Not used, only here for interface compatibility
+  schemas?: Array<any[]>; // Not used, only here for interface compatibility
+}
+
+/**
+ * Declares an Angular Module.
+ */
+export class NgModuleMetadata extends InjectableMetadata implements NgModuleMetadataType {
+
+  get providers(): any[] { return this._providers; }
+  private _providers: any[];
+
+  declarations: Array<Type|Type[]>;
+
+  imports: Array<Type|string>;
+
+  constructor(options: NgModuleMetadataType = {}) {
+    // We cannot use destructuring of the constructor argument because `exports` is a
+    // protected symbol in CommonJS and closure tries to aggressively optimize it away.
+    super();
+    this._providers = options.providers;
+    this.declarations = options.declarations;
+    this.imports = options.imports;
+  }
+}

--- a/src/core/util/bundler.ts
+++ b/src/core/util/bundler.ts
@@ -1,57 +1,118 @@
-import { global } from '../../facade/lang';
+import { global, isFunction } from '../../facade/lang';
 import { reflector } from '../reflection/reflection';
-import { ComponentMetadata } from '../directives/metadata_directives';
+import { ComponentMetadata, NgModuleMetadata } from '../directives/metadata_directives';
 import { getInjectableName, provide } from '../di/provider';
+import { isNgModule } from '../di/provider_util';
+
 import {
-  _isTypeRegistered, _normalizeProviders, _getNgModuleMetadataByType,
+  _isTypeRegistered, _normalizeProviders, _getAngular1ModuleMetadataByType,
   _registerTypeProvider
 } from '../di/reflective_provider';
 import { ListWrapper } from '../../facade/collections';
 
-export function bundle( ComponentClass: Type, otherProviders: any[] = [], NgModule?: ng.IModule ): ng.IModule {
+function _bundleComponent( ComponentClass: Type, otherProviders: any[] = [], existingAngular1Module?: ng.IModule ): ng.IModule {
 
   // Support registering downgraded ng2 components directly
   const downgradedNgComponentName = reflector.downgradedNg2ComponentName( ComponentClass );
   if (downgradedNgComponentName) {
-    const ngModule = NgModule || global.angular.module( downgradedNgComponentName, [] );
-    ngModule.directive( downgradedNgComponentName, ComponentClass );
-    return ngModule;
+    const angular1Module = existingAngular1Module || global.angular.module( downgradedNgComponentName, [] );
+    angular1Module.directive( downgradedNgComponentName, ComponentClass );
+    return angular1Module;
   }
 
-  const ngModuleName = getInjectableName( ComponentClass );
-  const ngModule = NgModule || global.angular.module( ngModuleName, [] );
+  const angular1ModuleName = getInjectableName( ComponentClass );
+  const angular1Module = existingAngular1Module || global.angular.module( angular1ModuleName, [] );
   const annotations = reflector.annotations( ComponentClass );
   const cmpAnnotation: ComponentMetadata = annotations[ 0 ];
   const { directives = [], pipes = [], providers = [], viewProviders = [] }={} = cmpAnnotation;
 
   // process component
   const [cmpName,cmpFactoryFn] = provide( ComponentClass );
-  const { providerName, providerMethod, moduleMethod } = _getNgModuleMetadataByType( ComponentClass );
+  const { providerName, providerMethod, moduleMethod } = _getAngular1ModuleMetadataByType( ComponentClass );
 
-  if ( _isTypeRegistered( cmpName, ngModule, providerName, providerMethod ) ) {
-    return ngModule;
+  if ( _isTypeRegistered( cmpName, angular1Module, providerName, providerMethod ) ) {
+    return angular1Module;
   }
 
   // @TODO register via this once requires are resolved for 3 types of attr directive from template
-  // _registerTypeProvider( ngModule, ComponentClass, { moduleMethod, name: cmpName, value: cmpFactoryFn } );
-  ngModule[moduleMethod]( cmpName, cmpFactoryFn );
+  // _registerTypeProvider( angular1Module, ComponentClass, { moduleMethod, name: cmpName, value: cmpFactoryFn } );
+  angular1Module[moduleMethod]( cmpName, cmpFactoryFn );
 
   // 1. process component/directive decorator providers/viewProviders/pipes
-  _normalizeProviders( ngModule, providers );
-  _normalizeProviders( ngModule, viewProviders );
-  _normalizeProviders( ngModule, pipes );
+  _normalizeProviders( angular1Module, providers );
+  _normalizeProviders( angular1Module, viewProviders );
+  _normalizeProviders( angular1Module, pipes );
 
 
   // step through all directives
   ListWrapper.flattenDeep(directives).forEach( ( directiveType: Type ) => {
-    bundle( directiveType, [], ngModule );
+    _bundleComponent( directiveType, [], angular1Module );
   } );
 
   // 2. process otherProviders argument
-  // - providers can be string(ngModule reference), Type, StringMap(providerLiteral)
+  // - providers can be string(angular1Module reference), Type, StringMap(providerLiteral)
   // - directives can't be registered as via global providers only @Injectable,@Pipe,{provide:any,use*:any}
-  // registerProviders(ngModule, otherProviders);
-  _normalizeProviders( ngModule, otherProviders );
+  // registerProviders(angular1Module, otherProviders);
+  _normalizeProviders( angular1Module, otherProviders );
 
-  return ngModule;
+  return angular1Module;
+}
+
+export function bundle( NgModuleClass: Type, otherProviders: any[] = [], existingAngular1Module?: ng.IModule ): ng.IModule {
+
+  const angular1ModuleName = getInjectableName( NgModuleClass );
+  const angular1Module = existingAngular1Module || global.angular.module( angular1ModuleName, [] );
+  const annotations = reflector.annotations( NgModuleClass );
+  const ngModuleAnnotation: NgModuleMetadata = annotations[ 0 ];
+  if (!isNgModule(ngModuleAnnotation)) {
+    throw new Error(`bundle() requires an @NgModule as it's first argument`)
+  }
+  const { declarations = [], providers = [], imports = [] }={} = ngModuleAnnotation;
+
+  /**
+   * Process `declarations`
+   */
+  ListWrapper.flattenDeep(declarations).forEach( ( directiveType: Type ) => {
+    _bundleComponent( directiveType, [], angular1Module );
+  } );
+
+  /**
+   * Process `providers`
+   */
+  _normalizeProviders( angular1Module, providers );
+
+  /**
+   * Process `imports`
+   */
+
+  // 1. imports which are not NgModules
+  const nonNgModuleImports: any[] = imports.filter((imported) => {
+    if (!isFunction(imported)) {
+      return true
+    }
+    const annotations = reflector.annotations( imported );
+    return !isNgModule(ngModuleAnnotation)
+  })
+
+  _normalizeProviders( angular1Module, nonNgModuleImports );
+
+  // 2.imports which are NgModules
+  const NgModuleImports: any[] = imports.filter((imported) => {
+    if (!isFunction(imported)) {
+      return false
+    }
+    const annotations = reflector.annotations( imported );
+    return isNgModule(ngModuleAnnotation)
+  })
+
+  NgModuleImports.forEach(( importedNgModule: Type ) => {
+    bundle(importedNgModule, [], angular1Module)
+  })
+
+  /**
+   * Process `otherProviders`
+   */
+  _normalizeProviders( angular1Module, otherProviders );
+
+  return angular1Module;
 }

--- a/src/platform/browser.ts
+++ b/src/platform/browser.ts
@@ -1,5 +1,10 @@
 import { createBootstrapFn } from './browser_utils'
 
-export const bootstrap = createBootstrapFn()
-
 export * from './title';
+
+export const platformBrowserDynamic = () => {
+  return {
+    bootstrapModule: createBootstrapFn(),
+  }
+}
+

--- a/src/platform/browser_utils.ts
+++ b/src/platform/browser_utils.ts
@@ -22,16 +22,15 @@ export function createBootstrapFn(bootstrapFn: Function = angular.bootstrap.bind
 
   /**
    * bootstrap angular app
-   * @param {Type}  rootComponent
+   * @param {Type}  NgModule
    * @param {Array<any>}  providers
    */
-  return function bootstrap(
-    rootComponent: Type,
-    providers: any[]
+  return function bootstrapModule(
+    NgModule: Type
   ) {
 
-    const ngModule = bundle( rootComponent, providers );
-    const ngModuleName = ngModule.name;
+    const angular1Module = bundle( NgModule );
+    const angular1ModuleName = angular1Module.name;
     const strictDi = true;
     const element = document;
 
@@ -40,13 +39,13 @@ export function createBootstrapFn(bootstrapFn: Function = angular.bootstrap.bind
         'Angular is running in the development mode. Call enableProdMode() to enable the production mode.'
       );
     } else {
-      angular.module( ngModuleName ).config( prodModeConfig );
+      angular.module( angular1ModuleName ).config( prodModeConfig );
     }
 
     const appRoot = _getAppRoot( element );
 
     angular.element( document ).ready( ()=> {
-      bootstrapFn( appRoot, [ ngModuleName ], {
+      bootstrapFn( appRoot, [ angular1ModuleName ], {
         strictDi
       } )
     } );

--- a/src/upgrade/upgrade_adapter.ts
+++ b/src/upgrade/upgrade_adapter.ts
@@ -1,5 +1,5 @@
 import { UpgradeAdapter, UpgradeAdapterInstance } from './upgrade';
-import { createBootstrapFn } from '../platform/browser_utils';
+// import { createBootstrapFn } from '../platform/browser_utils';
 import { reflector } from '../core/reflection/reflection';
 import { getInjectableName, OpaqueToken } from '../core/di';
 import { ProviderLiteral } from '../core/di/provider_util';
@@ -22,7 +22,7 @@ export class NgMetadataUpgradeAdapter {
      *
      * E.g. `upgradeAdapter.bootstrap(AppComponent, providers)`
      */
-    this.bootstrap = createBootstrapFn(this._upgradeAdapter.bootstrap.bind(this._upgradeAdapter));
+    // this.bootstrap = createBootstrapFn(this._upgradeAdapter.bootstrap.bind(this._upgradeAdapter));
   }
 
   /**

--- a/test/core/di/reflective_provider.spec.ts
+++ b/test/core/di/reflective_provider.spec.ts
@@ -5,8 +5,8 @@ import { global } from '../../../src/facade/lang';
 import { Component, Directive } from '../../../src/core/directives/decorators';
 import { Injectable, Inject } from '../../../src/core/di/decorators';
 import { Pipe } from '../../../src/core/pipes/decorators';
-import { _getNgModuleMetadataByType, resolveReflectiveProvider } from '../../../src/core/di/reflective_provider';
-import { createNgModule } from '../../utils';
+import { _getAngular1ModuleMetadataByType, resolveReflectiveProvider } from '../../../src/core/di/reflective_provider';
+import { createAngular1Module } from '../../utils';
 import { getInjectableName } from '../../../src/core/di/provider';
 import { createProvider } from '../../../src/core/di/provider_util';
 import { OpaqueToken } from '../../../src/core/di/opaque_token';
@@ -21,7 +21,7 @@ describe( `di/reflective_provider`, () => {
   const sandbox = sinon.sandbox.create();
 
   beforeEach( () => {
-    global.angular = createNgModule() as any;
+    global.angular = createAngular1Module() as any;
   } );
   afterEach( () => {
     sandbox.restore();
@@ -41,7 +41,7 @@ describe( `di/reflective_provider`, () => {
 
     } );
 
-    it( `should resolve value by useValue and provide metadata for ngModule`, () => {
+    it( `should resolve value by useValue and provide metadata for angular1Module`, () => {
 
       const ValueToken = new OpaqueToken('helloToken');
       const FalseToken = new OpaqueToken('helloFalse');
@@ -61,7 +61,7 @@ describe( `di/reflective_provider`, () => {
       expect( actual ).to.deep.equal( expected );
 
     } );
-    it( `should resolve service by useClass and provide metadata for ngModule`, () => {
+    it( `should resolve service by useClass and provide metadata for angular1Module`, () => {
 
       const classToken = new OpaqueToken('classToken');
 
@@ -87,7 +87,7 @@ describe( `di/reflective_provider`, () => {
       expect( actual ).to.deep.equal( expected );
 
     } );
-    it( `should resolve factory by useFactory and provide metadata for ngModule`, () => {
+    it( `should resolve factory by useFactory and provide metadata for angular1Module`, () => {
 
       const classToken = new OpaqueToken('classToken');
 
@@ -125,7 +125,7 @@ describe( `di/reflective_provider`, () => {
       expect( actual[ 1 ].value.$inject ).to.deep.equal( [ '$log','$http' ] );
 
     } );
-    it( `should resolve factory by useExisting and provide metadata for ngModule`, () => {
+    it( `should resolve factory by useExisting and provide metadata for angular1Module`, () => {
 
       @Injectable()
       class SomeInjectable{}
@@ -139,16 +139,16 @@ describe( `di/reflective_provider`, () => {
   } );
   describe( `#_normalizeProviders`, () => {
 
-    let ngModule: ng.IModule;
+    let angular1Module: ng.IModule;
     beforeEach( () => {
-      ngModule = global.angular.module( 'myApp', [] );
+      angular1Module = global.angular.module( 'myApp', [] );
     } );
 
     it( `should add dependant module to existing one if provider is string`, () => {
       const provider = 'ui.bootstrap.datepicker';
-      const updatedNgModule = _normalizeProviders( ngModule, [provider] );
+      const updatedAngular1Module = _normalizeProviders( angular1Module, [provider] );
 
-      expect( updatedNgModule.requires ).to.deep.equal( [ 'ui.bootstrap.datepicker' ] );
+      expect( updatedAngular1Module.requires ).to.deep.equal( [ 'ui.bootstrap.datepicker' ] );
     } );
     it( `should register $provide via value/service/factory if provider is ProviderLiteral`, () => {
 
@@ -160,11 +160,11 @@ describe( `di/reflective_provider`, () => {
         { provide: 'myHelloSvc', useClass: HelloSvc },
         { provide: 'myHelloFactory', useFactory: ()=>new HelloSvc() }
       ];
-      const updatedNgModule = _normalizeProviders( ngModule, providers );
+      const updatedAngular1Module = _normalizeProviders( angular1Module, providers );
 
-      expect( _isTypeRegistered( 'myValToken', updatedNgModule, '$provide', 'value' ) ).to.equal( true );
-      expect( _isTypeRegistered( 'myHelloSvc', updatedNgModule, '$provide', 'service' ) ).to.equal( true );
-      expect( _isTypeRegistered( 'myHelloFactory', updatedNgModule, '$provide', 'factory' ) ).to.equal( true );
+      expect( _isTypeRegistered( 'myValToken', updatedAngular1Module, '$provide', 'value' ) ).to.equal( true );
+      expect( _isTypeRegistered( 'myHelloSvc', updatedAngular1Module, '$provide', 'service' ) ).to.equal( true );
+      expect( _isTypeRegistered( 'myHelloFactory', updatedAngular1Module, '$provide', 'factory' ) ).to.equal( true );
 
     } );
     it( `should register $provide via service if provider is Decorated Type`, () => {
@@ -172,9 +172,9 @@ describe( `di/reflective_provider`, () => {
       class HelloSvc{}
 
       const provider = HelloSvc;
-      const updatedNgModule = _normalizeProviders( ngModule, [provider] );
+      const updatedAngular1Module = _normalizeProviders( angular1Module, [provider] );
 
-      expect( _isTypeRegistered( getInjectableName(HelloSvc), updatedNgModule, '$provide', 'service' ) ).to.equal( true );
+      expect( _isTypeRegistered( getInjectableName(HelloSvc), updatedAngular1Module, '$provide', 'service' ) ).to.equal( true );
     } );
     it( `should register $compileProvider via directive if provider is Decorated Type`, () => {
 
@@ -185,18 +185,18 @@ describe( `di/reflective_provider`, () => {
       class MyComponent { }
 
       const providers = [ HelloAttrDirective, MyComponent ];
-      const updatedNgModule = _normalizeProviders( ngModule, [ providers ] );
+      const updatedAngular1Module = _normalizeProviders( angular1Module, [ providers ] );
 
       expect( _isTypeRegistered(
         getInjectableName( HelloAttrDirective ),
-        updatedNgModule,
+        updatedAngular1Module,
         '$compileProvider',
         'directive'
       ) ).to.equal( true );
 
       expect( _isTypeRegistered(
         getInjectableName( MyComponent ),
-        updatedNgModule,
+        updatedAngular1Module,
         '$compileProvider',
         'directive'
       ) ).to.equal( true );
@@ -209,11 +209,11 @@ describe( `di/reflective_provider`, () => {
       }
 
       const provider = UpsHelloPipe;
-      const updatedNgModule = _normalizeProviders( ngModule, [provider] );
+      const updatedAngular1Module = _normalizeProviders( angular1Module, [provider] );
 
       expect( _isTypeRegistered(
         getInjectableName( UpsHelloPipe ),
-        updatedNgModule,
+        updatedAngular1Module,
         '$filterProvider',
         'register'
       ) ).to.equal( true );
@@ -228,9 +228,9 @@ describe( `di/reflective_provider`, () => {
         return internalRef;
       }
 
-      const updatedNgModule = _normalizeProviders( ngModule, [ stateConfig, createProvider( {} ) ] ) as any;
+      const updatedAngular1Module = _normalizeProviders( angular1Module, [ stateConfig, createProvider( {} ) ] ) as any;
 
-      expect( updatedNgModule._configBlocks ).to.deep.equal(
+      expect( updatedAngular1Module._configBlocks ).to.deep.equal(
         [
           [ '$injector', 'invoke', [ stateConfig ] ],
           [ '$injector', 'invoke', [ internalRef ] ]
@@ -239,47 +239,47 @@ describe( `di/reflective_provider`, () => {
 
     } );
     it( `should throw if non supported provider type is used`, () => {
-      expect( ()=>_normalizeProviders( ngModule, [ 23213 ] as any ) ).to.throw();
-      expect( ()=>_normalizeProviders( ngModule, [ {} ] as any ) ).to.throw();
-      expect( ()=>_normalizeProviders( ngModule, [ true ] as any ) ).to.throw();
+      expect( ()=>_normalizeProviders( angular1Module, [ 23213 ] as any ) ).to.throw();
+      expect( ()=>_normalizeProviders( angular1Module, [ {} ] as any ) ).to.throw();
+      expect( ()=>_normalizeProviders( angular1Module, [ true ] as any ) ).to.throw();
     } );
 
   } );
   describe( `#_isTypeRegistered`, () => {
 
-    let ngModule: ng.IModule;
+    let angular1Module: ng.IModule;
 
     @Component({selector:'my-cmp',template:'fooo'})
     class MyCmp{}
 
     beforeEach( () => {
-      ngModule = global.angular.module( 'myApp', [] );
+      angular1Module = global.angular.module( 'myApp', [] );
     } );
 
-    it( `should check ngModule for duplicates`, () => {
+    it( `should check angular1Module for duplicates`, () => {
 
-      let actual = _isTypeRegistered( 'myValue', ngModule, '$provide', 'value' );
+      let actual = _isTypeRegistered( 'myValue', angular1Module, '$provide', 'value' );
 
       expect( actual ).to.equal( false );
 
-      ngModule.value( ...provide( 'myValue', { useValue: 'hello' } ) );
-      actual = _isTypeRegistered( 'myValue', ngModule, '$provide', 'value' );
+      angular1Module.value( ...provide( 'myValue', { useValue: 'hello' } ) );
+      actual = _isTypeRegistered( 'myValue', angular1Module, '$provide', 'value' );
 
       expect( actual ).to.equal( true );
 
-      actual = _isTypeRegistered( 'myCmp', ngModule, '$compileProvider', 'directive' );
+      actual = _isTypeRegistered( 'myCmp', angular1Module, '$compileProvider', 'directive' );
 
       expect( actual ).to.equal( false );
 
-      ngModule.directive( ...provide( MyCmp ) );
-      actual = _isTypeRegistered( 'myCmp', ngModule, '$compileProvider', 'directive' );
+      angular1Module.directive( ...provide( MyCmp ) );
+      actual = _isTypeRegistered( 'myCmp', angular1Module, '$compileProvider', 'directive' );
 
       expect( actual ).to.equal( true );
 
     } );
 
   } );
-  describe(`#_getNgModuleMetadataByType`, () => {
+  describe(`#_getAngular1MetadataByType`, () => {
 
     @Component({selector:'foo',template:'hello'})
     class FooComponent{}
@@ -305,11 +305,11 @@ describe( `di/reflective_provider`, () => {
         return configPhase;
       }
 
-      expect( () => _getNgModuleMetadataByType( Configure ) ).to.not.throw();
-      expect( () => _getNgModuleMetadataByType( configPhase ) ).to.not.throw();
-      expect( () => _getNgModuleMetadataByType( configFactory( {} ) ) ).to.not.throw();
+      expect( () => _getAngular1ModuleMetadataByType( Configure ) ).to.not.throw();
+      expect( () => _getAngular1ModuleMetadataByType( configPhase ) ).to.not.throw();
+      expect( () => _getAngular1ModuleMetadataByType( configFactory( {} ) ) ).to.not.throw();
 
-      expect( _getNgModuleMetadataByType( configPhase ) ).to.deep.equal( {
+      expect( _getAngular1ModuleMetadataByType( configPhase ) ).to.deep.equal( {
         providerName: '$injector',
         providerMethod: 'invoke',
         moduleMethod: 'config'
@@ -317,12 +317,12 @@ describe( `di/reflective_provider`, () => {
 
     });
 
-    it(`should return ngModule registration method by Type Metadata`, () => {
+    it(`should return angular1Module registration method by Type Metadata`, () => {
       const actual = [
-        _getNgModuleMetadataByType( FooComponent ),
-        _getNgModuleMetadataByType( FooDirective ),
-        _getNgModuleMetadataByType( MyService ),
-        _getNgModuleMetadataByType( UpsPipe ),
+        _getAngular1ModuleMetadataByType( FooComponent ),
+        _getAngular1ModuleMetadataByType( FooDirective ),
+        _getAngular1ModuleMetadataByType( MyService ),
+        _getAngular1ModuleMetadataByType( UpsPipe ),
       ];
       const expected = [
         { providerName: '$compileProvider', providerMethod: 'directive', moduleMethod: 'directive' },
@@ -351,39 +351,39 @@ describe( `di/reflective_provider`, () => {
 
     class JustClass{}
 
-    let ngModule: ng.IModule;
+    let angular1Module: ng.IModule;
 
     beforeEach( () => {
-      ngModule = global.angular.module( 'myApp', [] );
+      angular1Module = global.angular.module( 'myApp', [] );
     } );
 
     it( `should do nothing if Class doesn't have annotation`, () => {
 
-      _registerTypeProvider( ngModule, JustClass, { moduleMethod: 'service', name: '', value: noop } );
-      expect( (ngModule as any)._invokeQueue ).to.deep.equal( [] );
+      _registerTypeProvider( angular1Module, JustClass, { moduleMethod: 'service', name: '', value: noop } );
+      expect( (angular1Module as any)._invokeQueue ).to.deep.equal( [] );
 
     } );
     it( `should register component/pipe/service via its name`, () => {
 
-      sandbox.spy(ngModule,'service');
-      sandbox.spy(ngModule,'filter');
-      sandbox.spy(ngModule,'directive');
+      sandbox.spy(angular1Module,'service');
+      sandbox.spy(angular1Module,'filter');
+      sandbox.spy(angular1Module,'directive');
 
-      _registerTypeProvider( ngModule, MyService, { moduleMethod: 'service', name: 'myService#1', value: noop } );
-      _registerTypeProvider( ngModule, UpsPipe, { moduleMethod: 'filter', name: 'ups', value: noop } );
-      _registerTypeProvider( ngModule, FooComponent, { moduleMethod: 'directive', name: 'foo', value: noop } );
+      _registerTypeProvider( angular1Module, MyService, { moduleMethod: 'service', name: 'myService#1', value: noop } );
+      _registerTypeProvider( angular1Module, UpsPipe, { moduleMethod: 'filter', name: 'ups', value: noop } );
+      _registerTypeProvider( angular1Module, FooComponent, { moduleMethod: 'directive', name: 'foo', value: noop } );
 
-      expect( (ngModule.service as Sinon.SinonSpy).calledOnce ).to.equal( true );
-      expect( (ngModule.filter as Sinon.SinonSpy).calledOnce ).to.equal( true );
-      expect( (ngModule.directive as Sinon.SinonSpy).calledOnce ).to.equal( true );
+      expect( (angular1Module.service as Sinon.SinonSpy).calledOnce ).to.equal( true );
+      expect( (angular1Module.filter as Sinon.SinonSpy).calledOnce ).to.equal( true );
+      expect( (angular1Module.directive as Sinon.SinonSpy).calledOnce ).to.equal( true );
 
     } );
     it( `should register directive via 3 types of template usage (name),[name],name`, () => {
 
-      sandbox.spy( ngModule, 'directive' );
-      const spy = ngModule.directive as Sinon.SinonSpy;
+      sandbox.spy( angular1Module, 'directive' );
+      const spy = angular1Module.directive as Sinon.SinonSpy;
 
-      _registerTypeProvider( ngModule, FooDirective, { moduleMethod: 'directive', name: 'foo', value: noop } );
+      _registerTypeProvider( angular1Module, FooDirective, { moduleMethod: 'directive', name: 'foo', value: noop } );
 
       expect( spy.calledThrice ).to.equal( true );
       expect( spy.calledWith( 'foo', noop ) ).to.equal( true );

--- a/test/core/util/bundler.spec.ts
+++ b/test/core/util/bundler.spec.ts
@@ -1,8 +1,8 @@
 import * as sinon from 'sinon';
 import { expect } from 'chai';
 import { global } from '../../../src/facade/lang';
-import { Component } from '../../../src/core/directives/decorators';
-import { createNgModule } from '../../utils';
+import { Component, NgModule } from '../../../src/core/directives/decorators';
+import { createAngular1Module } from '../../utils';
 import { provide } from '../../../src/core/di';
 import { bundle } from '../../../src/core/util/bundler';
 import { Pipe } from '../../../src/core/pipes/decorators';
@@ -14,7 +14,7 @@ describe( `util/bundler`, () => {
 
   let sandbox: Sinon.SinonSandbox;
   beforeEach( () => {
-    global.angular = createNgModule() as any;
+    global.angular = createAngular1Module() as any;
     sandbox = sinon.sandbox.create();
   } );
   afterEach( () => {
@@ -56,17 +56,14 @@ describe( `util/bundler`, () => {
     @Component( {
       selector: 'nested',
       template: `Im nested`,
-      viewProviders: [ MyPrivateService ],
-      pipes: [ UpsPipe ]
+      viewProviders: [ MyPrivateService ]
     } )
     class NestedComponent {
     }
 
     @Component( {
       selector: 'child-one',
-      directives: [ NestedComponent ],
       providers: [ MyService, 'ui.bootstrap.modal' ],
-      pipes: [ UpsPipe ],
       template: `hello Im childOne <nested></nested>`
     } )
     class ChildOneComponent {
@@ -75,9 +72,7 @@ describe( `util/bundler`, () => {
     const MyFactoryToken = new OpaqueToken( 'myFactory' );
     @Component( {
       selector: 'child-two',
-      directives: [ NestedComponent ],
       providers: [ OtherService, MyService, { provide: MyFactoryToken, deps: [ '$q' ], useFactory: ( $q )=>({}) } ],
-      pipes: [ UpsPipe ],
       template: `hello Im childTwo <nested></nested>`
     } )
     class ChildTwoComponent {
@@ -85,7 +80,6 @@ describe( `util/bundler`, () => {
 
     @Component( {
       selector: 'app',
-      directives: [ ChildOneComponent, ChildTwoComponent ],
       providers: [ MySingleton, { provide: 'tokenAsClass', useClass: ViaProviderLiteralService } ],
       template: `Hello App
         <child-one></child-one>
@@ -95,19 +89,37 @@ describe( `util/bundler`, () => {
     class AppComponent {
     }
 
-    it( `should create module which has name as root component selector`, () => {
+    it( `should use an existing Angular 1 module, if one is provided`, () => {
 
-      const ngModule = bundle( AppComponent );
+      @NgModule({
+        declarations: [ AppComponent, ChildOneComponent, UpsPipe, NestedComponent, ChildTwoComponent ],
+      })
+      class AppModule {
+      }
 
-      expect( ngModule.name ).to.equal( 'app' );
-      expect( ngModule.requires ).to.deep.equal( ['ui.bootstrap.modal'] );
+      const existingAngular1Module = createAngular1Module().module( 'existing', [] );
+
+      const angular1Module = bundle( AppModule );
+      const angular1ModuleUsingExisting = bundle( AppModule, [], existingAngular1Module as any );
+
+      expect( angular1Module.name ).to.contain( 'appModule' );
+      expect( angular1ModuleUsingExisting.name ).to.equal( 'existing' );
 
     } );
 
     it( `should parse whole component tree and register all providers,viewProviders,pipes,directives`, () => {
 
-      const thirdPartyModule = createNgModule().module( '3rdParty', [] ).name;
-      const ngModule = bundle( AppComponent, [ SomeGlobalService, thirdPartyModule ] );
+      const thirdPartyModule = createAngular1Module().module( '3rdParty', [] ).name;
+
+      @NgModule({
+        declarations: [ AppComponent, ChildOneComponent, UpsPipe, NestedComponent, ChildTwoComponent ],
+        providers: [ SomeGlobalService ],
+        imports: [ thirdPartyModule ]
+      })
+      class AppModule {
+      }
+
+      const angular1Module = bundle( AppModule );
 
       const expectedInvokeQueue = [
         [ '$compileProvider', 'directive', provide( AppComponent ) ],
@@ -123,7 +135,7 @@ describe( `util/bundler`, () => {
         [ '$provide', 'factory', provide( MyFactoryToken, { useFactory: ()=>({}) } ) ],
         [ '$provide', 'service', provide( SomeGlobalService ) ]
       ];
-      const actualInvokeQueue = (ngModule as any)._invokeQueue;
+      const actualInvokeQueue = (angular1Module as any)._invokeQueue;
       const actual = _invokeQueueToCompare( actualInvokeQueue, false );
       const expected = _invokeQueueToCompare( expectedInvokeQueue, false );
 
@@ -132,7 +144,7 @@ describe( `util/bundler`, () => {
       // console.log( 'expected:',expected );
 
       expect( actual ).to.deep.equal( expected );
-      expect( ngModule.requires ).to.deep.equal( [ 'ui.bootstrap.modal','3rdParty' ] );
+      expect( angular1Module.requires ).to.deep.equal( [ 'ui.bootstrap.modal','3rdParty' ] );
 
     } );
 
@@ -148,13 +160,17 @@ describe( `util/bundler`, () => {
       @Component( {
         selector: 'app-with-plugin',
         template: 'hello',
-        directives: [ PluginFooDirectives, YoDirective ],
-        providers: [ PluginFooProviders, MyPrivateService ],
-        pipes: [ PluginFooPipes ]
+        providers: [ PluginFooProviders, MyPrivateService ]
       } )
       class AppWithPluginComponent {}
 
-      const ngModule = bundle( AppWithPluginComponent );
+      @NgModule({
+        declarations: [ AppWithPluginComponent, PluginFooPipes, PluginFooDirectives, YoDirective ],
+      })
+      class AppWithPluginModule {
+      }
+
+      const angular1Module = bundle( AppWithPluginModule );
 
       const expectedInvokeQueue = [
         [ '$compileProvider', 'directive', provide( AppWithPluginComponent ) ],
@@ -165,7 +181,7 @@ describe( `util/bundler`, () => {
         [ '$compileProvider', 'directive', provide( NestedComponent ) ],
         [ '$compileProvider', 'directive', provide( YoDirective ) ]
       ];
-      const actualInvokeQueue = (ngModule as any)._invokeQueue;
+      const actualInvokeQueue = (angular1Module as any)._invokeQueue;
       const actual = _invokeQueueToCompare( actualInvokeQueue, false );
       const expected = _invokeQueueToCompare( expectedInvokeQueue, false );
 
@@ -177,7 +193,7 @@ describe( `util/bundler`, () => {
 
     } );
 
-    it( `should allow ngModule.config within otherProviders setup`, () => {
+    it( `should allow angular1Module.config within otherProviders setup`, () => {
 
       @Injectable()
       class MyDynamicService {}
@@ -199,7 +215,13 @@ describe( `util/bundler`, () => {
       } )
       class PureAppComponent {}
 
-      const ngModule = bundle( PureAppComponent, [ configPhase ] );
+      @NgModule({
+        declarations: [ PureAppComponent ],
+      })
+      class AppModule {
+      }
+
+      const angular1Module = bundle( AppModule, [ configPhase ] );
 
       const expectedInvokeQueue = [
         [ '$compileProvider', 'directive', provide( PureAppComponent ) ],
@@ -215,12 +237,12 @@ describe( `util/bundler`, () => {
         [ '$injector', 'invoke', [ configPhase ] ]
       ];
 
-      const actualConfigBlocks = (ngModule as any)._configBlocks;
-      const actualInvokeQueue = (ngModule as any)._invokeQueue;
+      const actualConfigBlocks = (angular1Module as any)._configBlocks;
+      const actualInvokeQueue = (angular1Module as any)._invokeQueue;
 
       expect( actualConfigBlocks ).to.deep.equal( expectedConfigBlocks );
 
-      _execConfigBlocks(ngModule);
+      _execConfigBlocks(angular1Module);
 
       const actual = _invokeQueueToCompare( actualInvokeQueue, false );
       const expected = _invokeQueueToCompare( expectedInvokeQueue, false );

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -4,7 +4,7 @@ import { isArray, isFunction, assign } from '../src/facade/lang';
 // _private helpers for testing
 // ============================
 
-export function createNgModule() {
+export function createAngular1Module() {
   return {
     module( name, requires?: string[] ){
       const _m = {


### PR DESCRIPTION
Hey @Hotell,

This PR does a few things:

- Updates the test boilerplate for `bundle()` - note that the assertions around invokeQueue are the same before and after the changes. This demonstrates that the underlying conversion to angular 1 modules is consistent!
- You obviously could not have know that the Angular team would come up with a special `NgModule` for Angular 2, and so you have used variations of `ngModule` a lot in the code as a shorthand for an angular 1 module. I have have disambiguated that usage by renaming old occurrences to `angular1Module`: `NgModule` should now only ever refer to the Angular 2 concept.

Documentation and ngUpgrade updates to follow in subsequent PRs, but I think this gives us a base with which to start a beta 