### PR TITLE
refactor(core): Remove directives and pipes from ComponentMetadata

### DIFF
--- a/src/core/directives/metadata_directives.ts
+++ b/src/core/directives/metadata_directives.ts
@@ -938,13 +938,11 @@ export class ComponentMetadata extends DirectiveMetadata {
   template: string;
   styleUrls: string[];
   styles: string[];
-  directives: Array<Type | any[]>;
-  pipes: Array<Type | any[]>;
 
   constructor({
     selector, inputs, attrs, outputs, host, exportAs, moduleId, providers, viewProviders,
     changeDetection = ChangeDetectionStrategy.Default, queries, templateUrl, template,
-    styleUrls, styles, directives, pipes, legacy
+    styleUrls, styles, legacy
   }: {
     selector?: string,
     inputs?: string[],
@@ -961,8 +959,6 @@ export class ComponentMetadata extends DirectiveMetadata {
     template?: string,
     styleUrls?: string[],
     styles?: string[],
-    directives?: Array<Type | any[]>,
-    pipes?: Array<Type | any[]>,
     legacy?: LegacyDirectiveDefinition
   } = {}) {
     super({
@@ -983,8 +979,6 @@ export class ComponentMetadata extends DirectiveMetadata {
     this.template = template;
     this.styleUrls = styleUrls;
     this.styles = styles;
-    this.directives = directives;
-    this.pipes = pipes;
     this.moduleId = moduleId;
   }
 }

--- a/src/core/util/bundler.ts
+++ b/src/core/util/bundler.ts
@@ -24,7 +24,7 @@ function _bundleComponent( ComponentClass: Type, otherProviders: any[] = [], exi
   const angular1Module = existingAngular1Module || global.angular.module( angular1ModuleName, [] );
   const annotations = reflector.annotations( ComponentClass );
   const cmpAnnotation: ComponentMetadata = annotations[ 0 ];
-  const { directives = [], pipes = [], providers = [], viewProviders = [] }={} = cmpAnnotation;
+  const { providers = [], viewProviders = [] }={} = cmpAnnotation;
 
   // process component
   const [cmpName,cmpFactoryFn] = provide( ComponentClass );
@@ -38,16 +38,9 @@ function _bundleComponent( ComponentClass: Type, otherProviders: any[] = [], exi
   // _registerTypeProvider( angular1Module, ComponentClass, { moduleMethod, name: cmpName, value: cmpFactoryFn } );
   angular1Module[moduleMethod]( cmpName, cmpFactoryFn );
 
-  // 1. process component/directive decorator providers/viewProviders/pipes
+  // 1. process component/directive decorator providers/viewProviders
   _normalizeProviders( angular1Module, providers );
   _normalizeProviders( angular1Module, viewProviders );
-  _normalizeProviders( angular1Module, pipes );
-
-
-  // step through all directives
-  ListWrapper.flattenDeep(directives).forEach( ( directiveType: Type ) => {
-    _bundleComponent( directiveType, [], angular1Module );
-  } );
 
   // 2. process otherProviders argument
   // - providers can be string(angular1Module reference), Type, StringMap(providerLiteral)

--- a/src/upgrade/upgrade_adapter.ts
+++ b/src/upgrade/upgrade_adapter.ts
@@ -1,8 +1,3 @@
-<<<<<<< f1614e895e2a925e7b66f7c86d19df610a110d30
-=======
-import { UpgradeAdapter, UpgradeAdapterInstance } from './upgrade';
-// import { createBootstrapFn } from '../platform/browser_utils';
->>>>>>> refactor(core): Add NgModule, use it for angular1Module bundling
 import { reflector } from '../core/reflection/reflection';
 import { getInjectableName, OpaqueToken } from '../core/di';
 import { ProviderLiteral } from '../core/di/provider_util';

--- a/src/upgrade/upgrade_adapter.ts
+++ b/src/upgrade/upgrade_adapter.ts
@@ -1,3 +1,8 @@
+<<<<<<< f1614e895e2a925e7b66f7c86d19df610a110d30
+=======
+import { UpgradeAdapter, UpgradeAdapterInstance } from './upgrade';
+// import { createBootstrapFn } from '../platform/browser_utils';
+>>>>>>> refactor(core): Add NgModule, use it for angular1Module bundling
 import { reflector } from '../core/reflection/reflection';
 import { getInjectableName, OpaqueToken } from '../core/di';
 import { ProviderLiteral } from '../core/di/provider_util';


### PR DESCRIPTION
BREAKING CHANGE: All Pipes and Components must now be registered via an
NgModule's declarations array.