### PR TITLE
chore(package): Update rxjs to 5.0.0-rc.1, and TypeScript to 2.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,17 +42,17 @@
     "live-server": "0.8.2",
     "mocha": "2.3.4",
     "reflect-metadata": "0.1.3",
-    "rxjs": "5.0.0-beta.11",
+    "rxjs": "5.0.0-rc.1",
     "sinon": "1.17.2",
     "systemjs": "0.19.6",
     "systemjs-builder": "0.14.11",
     "ts-node": "0.7.3",
-    "typescript": "1.8.10",
+    "typescript": "2.0.3",
     "typings": "1.0.4",
     "validate-commit-msg": "2.0.0"
   },
   "peerDependencies": {
-    "rxjs": "5.0.0-beta.11",
+    "rxjs": "5.0.0-rc.1",
     "angular": ">=1.4.x",
     "reflect-metadata": "0.1.x"
   },

--- a/src/core/directives/binding/binding_parser.ts
+++ b/src/core/directives/binding/binding_parser.ts
@@ -194,7 +194,7 @@ export function _setupOutputs(
  * @private
  * @deprecated
  */
-export function _parseBindings({ inputs=[], outputs=[], attrs=[] }): ParsedBindings {
+export function _parseBindings({ inputs=[], outputs=[], attrs=[] }: { inputs: string[], outputs: string[], attrs: string[] }): ParsedBindings {
 
   const SPLIT_BY = ':';
 

--- a/src/core/directives/query/children_resolver.ts
+++ b/src/core/directives/query/children_resolver.ts
@@ -323,7 +323,7 @@ export function _getParentCheckNotifiers( ctrl: DirectiveCtrl, requiredCtrls: Ob
               return false;
             }
             // check if current child is really queried from its parent
-            return ctrl instanceof <Type>propMetaInstance.selector;
+            return ctrl instanceof (propMetaInstance.selector as Type);
 
           } )
           .forEach( ( propMetaInstance: QueryMetadata )=> {

--- a/src/core/directives/query/children_resolver.ts
+++ b/src/core/directives/query/children_resolver.ts
@@ -323,7 +323,7 @@ export function _getParentCheckNotifiers( ctrl: DirectiveCtrl, requiredCtrls: Ob
               return false;
             }
             // check if current child is really queried from its parent
-            return ctrl instanceof propMetaInstance.selector;
+            return ctrl instanceof <Type>propMetaInstance.selector;
 
           } )
           .forEach( ( propMetaInstance: QueryMetadata )=> {


### PR DESCRIPTION
BREAKING CHANGE: The rxjs peerDependency has been updated to 5.0.0-rc.1,
and this in turn requires TypeScript of 2.x and above.