### PR TITLE
Import Type from facade, to ensure it is also imported in .d.ts

### DIFF
--- a/src/core/di/key.ts
+++ b/src/core/di/key.ts
@@ -6,7 +6,7 @@ import {StringWrapper} from '../../facade/primitives';
 import {isString} from '../../facade/lang';
 import {OpaqueToken} from './opaque_token';
 import {ListWrapper} from '../../facade/collections';
-import {isType} from '../../facade/lang';
+import {isType, Type} from '../../facade/lang';
 import {getTypeName} from '../../facade/lang';
 
 /**

--- a/src/core/di/provider_util.ts
+++ b/src/core/di/provider_util.ts
@@ -1,4 +1,4 @@
-import { isString, isPresent } from '../../facade/lang';
+import { isString, isPresent, Type } from '../../facade/lang';
 import { DirectiveMetadata, ComponentMetadata } from '../directives/metadata_directives';
 import { PipeMetadata } from '../pipes/metadata';
 

--- a/src/core/di/reflective_provider.ts
+++ b/src/core/di/reflective_provider.ts
@@ -1,4 +1,4 @@
-import { isType, isArray, isString, getFuncName, isBlank, isPresent } from '../../facade/lang';
+import { isType, isArray, isString, getFuncName, isBlank, isPresent, Type } from '../../facade/lang';
 
 import { reflector } from '../reflection/reflection';
 

--- a/src/core/directives/controller/controller_factory.ts
+++ b/src/core/directives/controller/controller_factory.ts
@@ -4,7 +4,7 @@ import { DirectiveMetadata, ComponentMetadata } from '../metadata_directives';
 import { ChangeDetectorRef } from '../../change_detection/change_detector_ref';
 import { _createDirectiveBindings } from '../binding/binding_factory';
 import { isAttrDirective } from '../directives_utils';
-import { isFunction, isJsObject, isArray, getFuncName, isString } from '../../../facade/lang';
+import { isFunction, isJsObject, isArray, getFuncName, isString, Type } from '../../../facade/lang';
 import { StringWrapper } from '../../../facade/primitives';
 import { DirectiveCtrl, NgmDirective } from '../constants';
 import { REQUIRE_PREFIX_REGEXP } from './constants';

--- a/src/core/directives/directive_provider.ts
+++ b/src/core/directives/directive_provider.ts
@@ -1,5 +1,5 @@
 import { DirectiveResolver } from '../linker/directive_resolver';
-import { assign, isFunction, noop, resolveDirectiveNameFromSelector, stringify, isJsObject } from '../../facade/lang';
+import { assign, isFunction, noop, resolveDirectiveNameFromSelector, stringify, isJsObject, Type } from '../../facade/lang';
 import { StringMapWrapper } from '../../facade/collections';
 import { resolveImplementedLifeCycleHooks, ImplementedLifeCycleHooks } from '../linker/directive_lifecycles_reflector';
 import { ChildrenChangeHook } from '../linker/directive_lifecycle_interfaces';

--- a/src/core/directives/query/children_resolver.ts
+++ b/src/core/directives/query/children_resolver.ts
@@ -1,4 +1,4 @@
-import { global, isString, noop, isType, isJsObject, getFuncName, isFunction } from '../../../facade/lang';
+import { global, isString, noop, isType, isJsObject, getFuncName, isFunction, Type } from '../../../facade/lang';
 import { ListWrapper, StringMapWrapper } from '../../../facade/collections';
 import { ChildrenChangeHook } from '../../linker/directive_lifecycle_interfaces';
 import { reflector } from '../../reflection/reflection';

--- a/src/core/util/bundler.ts
+++ b/src/core/util/bundler.ts
@@ -1,4 +1,4 @@
-import { global } from '../../facade/lang';
+import { global, Type } from '../../facade/lang';
 import { reflector } from '../reflection/reflection';
 import { ComponentMetadata } from '../directives/metadata_directives';
 import { getInjectableName, provide } from '../di/provider';

--- a/src/facade/exceptions.ts
+++ b/src/facade/exceptions.ts
@@ -1,4 +1,4 @@
-import { getFuncName } from './lang';
+import { getFuncName, Type } from './lang';
 
 export class BaseException extends Error {
   public stack: any;

--- a/src/platform/browser_utils.ts
+++ b/src/platform/browser_utils.ts
@@ -1,4 +1,4 @@
-import { assertionsEnabled } from '../facade/lang';
+import { assertionsEnabled, Type } from '../facade/lang';
 import { bundle } from '../core/util/bundler';
 
 type AppRoot = string | Element | Document;

--- a/src/router-deprecated/route_definition.ts
+++ b/src/router-deprecated/route_definition.ts
@@ -1,3 +1,4 @@
+import { Type } from "../facade/lang";
 /**
  * `RouteDefinition` defines a route within a {@link RouteConfig} decorator.
  *

--- a/src/router-deprecated/route_registry.ts
+++ b/src/router-deprecated/route_registry.ts
@@ -2,6 +2,7 @@ import { Injectable } from '../core/di/decorators';
 import { RouteDefinition } from './route_definition';
 import { Instruction } from './instructions';
 import { OpaqueToken } from '../core/di/opaque_token';
+import { Type } from "../facade/lang";
 
 
 /**

--- a/src/testing/utils.ts
+++ b/src/testing/utils.ts
@@ -1,5 +1,6 @@
 import { getInjectableName } from '../core/di/provider';
 import { StringWrapper } from '../facade/primitives';
+import { Type } from "../facade/lang";
 
 // public helpers
 

--- a/src/upgrade/upgrade.ts
+++ b/src/upgrade/upgrade.ts
@@ -2,6 +2,7 @@
  * `UgradeAdapterRef` controls a hybrid AngularJS v1 / Angular v2 application,
  * but we don't have a use for it right now so no point in creating an interface for it...
  */
+import { Type } from "../facade/lang";
 export type UgradeAdapterRef = void;
 
 export interface UpgradeAdapter {

--- a/src/upgrade/upgrade_adapter.ts
+++ b/src/upgrade/upgrade_adapter.ts
@@ -3,7 +3,7 @@ import { createBootstrapFn } from '../platform/browser_utils';
 import { reflector } from '../core/reflection/reflection';
 import { getInjectableName, OpaqueToken } from '../core/di';
 import { ProviderLiteral } from '../core/di/provider_util';
-import { resolveDirectiveNameFromSelector } from '../facade/lang';
+import { resolveDirectiveNameFromSelector, Type } from '../facade/lang';
 
 export class NgMetadataUpgradeAdapter {
 

--- a/test/upgrade/upgrade_adapter.spec.ts
+++ b/test/upgrade/upgrade_adapter.spec.ts
@@ -3,6 +3,7 @@ import * as sinon from 'sinon';
 import { NgMetadataUpgradeAdapter } from '../../src/upgrade/upgrade_adapter'
 import { Component, OpaqueToken, getInjectableName } from '../../core'
 import { reflector } from '../../src/core/reflection/reflection';
+import { Type } from "../../src/facade/lang";
 
 class MockAngularUpgradeAdapter {
   bootstrap(element: Element, modules?: any[], config?: angular.IAngularBootstrapConfig): void {


### PR DESCRIPTION
As it seams, that in some configurations the global manual typings aren't properly used it may be better to import Type from facade instead of relaying on global.
