### PR TITLE
test(facade/lang): support Node 6 and Windows environments

### DIFF
--- a/src/facade/lang.ts
+++ b/src/facade/lang.ts
@@ -171,7 +171,7 @@ export function stringify( token ): string {
   var newLineIndex = res.indexOf( "\n" );
   return (newLineIndex === -1)
     ? res
-    : res.substring( 0, newLineIndex );
+    : res.substring( 0, newLineIndex ).replace('\r', '');
 }
 
 /**

--- a/test/facade/lang.spec.ts
+++ b/test/facade/lang.spec.ts
@@ -72,14 +72,14 @@ describe( `facade/lang`, ()=> {
 
     it( 'should return first line string of function definition if the function is anonymous',  ()=> {
 
-      let anonFn = function () {};
-      let anonFnMultiLine = function () {
+      let anonFn = stringify(function () {});
+      let anonFnMultiLine = stringify(function () {
         console.log( 'yoo' );
         return null;
-      };
+      });
 
-      expect( stringify(anonFn) ).to.equal( 'function () { }' );
-      expect( stringify(anonFnMultiLine) ).to.equal( 'function () {' );
+      expect( anonFn ).to.equal( 'function () { }' );
+      expect( anonFnMultiLine ).to.equal( 'function () {' );
 
     } );
 


### PR DESCRIPTION
Node 6 tries to name anonymous functions if assigned to a variable
Windows adds a carriage return character to the end of line which should not be included by stringify

This clears the way for easier contributions to ng-metadata.