### PR TITLE
fix(async pipe): prevent firing $digest after scope is destroyed.

### DIFF
--- a/playground/app/components/async-example/async-destroy.component.ts
+++ b/playground/app/components/async-example/async-destroy.component.ts
@@ -1,0 +1,107 @@
+import 'rxjs/add/operator/take';
+import 'rxjs/add/operator/takeUntil';
+import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/distinctUntilChanged';
+import { Component, Inject, Input, OnDestroy } from 'ng-metadata/core';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { Subject } from 'rxjs/Subject';
+
+interface State {
+  data: number;
+}
+
+@Component({
+  selector: 'async-destroy-child',
+  template: (
+    `State is {{ ($ctrl.state$ | async:this).data }}`
+  )
+})
+export class AsyncDestroyChildComponent implements OnDestroy {
+  @Input('<') state$: BehaviorSubject<State>;
+
+  private destroy = false;
+
+  constructor(@Inject('$scope') private $scope: ng.IScope){
+    this.$scope.$watch(() => {
+      // watch digest loops
+      if (this.destroy) {
+        alert('Memory leak');
+      }
+      return true;
+    },() => {});
+  }
+
+  ngOnDestroy() {
+    this.destroy = true;
+  }
+}
+
+@Component({
+  selector: 'async-destroy-container',
+  template: (
+    `<async-destroy-child 
+        state$="$ctrl.state$"></async-destroy-child>`
+  )
+})
+export class AsyncDestroyContainerComponent implements OnDestroy {
+  @Input('<') state$: BehaviorSubject<State>;
+
+  constructor(){}
+
+  ngOnDestroy() {
+    // to start synchronous effects while destroy phase
+    this.state$.next({data: 1});
+  }
+}
+
+@Component({
+  selector: 'async-destroy',
+  template: (
+    `<hl>
+     <h4>Check for Memory leak</h4>
+     <button ng-click="$ctrl.toggle()">Start</button>
+     <div ng-if="$ctrl.showChild$ | async:this">
+        <async-destroy-container
+          state$="$ctrl.state$"></async-destroy-container>
+    </div>`
+  )
+})
+export class AsyncDestroyComponent implements OnDestroy {
+  state$ = new BehaviorSubject<State>({
+    data: 1
+  });
+
+  // observable to create/destroy underlying component
+  showChild$ = this.state$.map((state: State) => state.data % 2)
+    .distinctUntilChanged();
+
+  private ngOnDestroy$ = new Subject<void>();
+
+  constructor(@Inject('$interval') private $interval: ng.IIntervalService){
+    this.runEffects();
+  }
+
+  ngOnDestroy() {
+    this.ngOnDestroy$.next();
+    this.ngOnDestroy$.complete();
+  }
+
+  toggle() {
+    this.state$.take(1)
+      .subscribe((state: State) => {
+        this.state$.next({...state,
+          data: state.data + 1});
+      });
+  }
+
+  private runEffects() {
+    // simulate some synchronous effects
+    this.state$
+      .takeUntil(this.ngOnDestroy$)
+      .subscribe((state: State) => {
+        if (state.data % 3) { // to prevent infinite loop
+          this.state$.next({...state, data: state.data + 1});
+        }
+      });
+  }
+}

--- a/playground/app/components/async-example/async-example.component.ts
+++ b/playground/app/components/async-example/async-example.component.ts
@@ -48,6 +48,7 @@ export class AsyncTaskComponent {
       </ul>
       <pre style="overflow:auto;max-height:250px;">{{ $ctrl.repos | async | json }}</pre>
     </div>
+    <async-destroy class="clearfix"></async-destroy>
     `
   )
 })

--- a/playground/app/components/async-example/async-example.module.ts
+++ b/playground/app/components/async-example/async-example.module.ts
@@ -1,10 +1,11 @@
 import { NgModule } from 'ng-metadata/core';
 import { AsyncExampleComponent, AsyncTaskComponent } from './async-example.component';
+import { AsyncDestroyChildComponent, AsyncDestroyComponent, AsyncDestroyContainerComponent } from './async-destroy.component';
 
 @NgModule({
   imports: [],
   // exports, bootstrap, entryComponents have no real functionality yet
   exports: [AsyncExampleComponent],
-  declarations: [AsyncExampleComponent, AsyncTaskComponent]
+  declarations: [AsyncExampleComponent, AsyncTaskComponent, AsyncDestroyComponent, AsyncDestroyChildComponent, AsyncDestroyContainerComponent]
 })
 export class AsyncExampleModule{}


### PR DESCRIPTION
Issue:
async pipe could trigger digest after scope was destroyed.
It could result in memory leak, because digest will trigger async pipe (like a filter), making it to subscribe observable in already destroyed scope (and `$destroy` won't happen again). 
The source of the problem for async pipe is `_markForCheck` method, that sets timeout, and triggers `$digest` without checking if scope is destroyed.
Solution: track timeouts and clean them while `_dispose` and before setting new timeout.

For test, set of `async-destroy` components were created. Clicking 'start' button dispatches change in `Subject` imitating application state. If 'Memory leak' (when digest called after scope being destroyed) happened, alert message will be shown. To test fail scenario comment `clearTimeout` lines if `async` pipe.
The key point is "middle" `async-destroy-container` component that on `$destroy` triggers synchronous change of `Subject`. Thats a scenario when component on destroy want to change the state of application. 